### PR TITLE
test travis on 0.3 and 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.3
+  - 0.4
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
since release is 0.4 now and this package still supports 0.3 according to REQUIRE
