### PR TITLE
Lightgraph poc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _build
 docs/build/
 docs/site/
 .DS_Store
+*.cov

--- a/src/EvolvingGraphs.jl
+++ b/src/EvolvingGraphs.jl
@@ -70,6 +70,9 @@ include("graph_types/incidence_list.jl")
 
 include("show.jl")
 
+# LightGraphs interface
+@require LightGraphs include("read_write/lg_interface.jl")
+
 # algorithms
 include("algorithms/bfs.jl")
 include("algorithms/dfs.jl")

--- a/src/EvolvingGraphs.jl
+++ b/src/EvolvingGraphs.jl
@@ -1,6 +1,6 @@
 module EvolvingGraphs
 
-import Base: ==, show, issorted, deepcopy, length, eltype, push!, append!
+import Base: ==, show, issorted, deepcopy, length, eltype, push!, append!, reverse
 using Requires
 
 

--- a/src/read_write/lg_interface.jl
+++ b/src/read_write/lg_interface.jl
@@ -1,24 +1,43 @@
+LightGraphs.nv(g::AbstractGraph) = num_nodes(g)
+LightGraphs.ne(g::AbstractGraph) = num_edges(g)
+LightGraphs.is_directed(g::AbstractGraph) = is_directed(g)
 
-LightGraphs.nv(g::DiGraph) = length(g.nodes)
+function LightGraphs.outneighbors(g::AbstractStaticGraph{V}, v::V) where V
+    edges = out_edges(g, v)
+    return Node{V}[target(e) for e in edges]
+end
+
+function LightGraphs.inneighbors(g::AbstractStaticGraph{V}, v::V) where V
+    edges = in_edges(g, v)
+    return Node{V}[source(e) for e in edges]
+end
+
+LightGraphs.src(e::AbstractEdge{V}) where V = source(e) 
+LightGraphs.dst(e::AbstractEdge{V}) where V = target(e) 
+
+LightGraphs.has_edge(g::AbstractGraph{V}, e::AbstractEdge{V}) where V = has_edge(g,e)
+LightGraphs.has_vertex(g::AbstractGraph{V}, n::AbstractNode{V}) where V = has_node(g,n)
+
+function Base.reverse(e::AbstractEdge{V}) where V = edge_reverse(e)
+
+LightGraphs.edges(g::AbstractGraph{V}) where V = edges(g)
+LightGraphs.edgetype(::AbstractGraph{V}) where V = AbstractEdge{V}
+
+LightGraphs.vertices(g::AbstractGraph{V}) where V = nodes(g)
+
+LightGraphs.add_edge!(g::AbstractStaticGraph{V}, e::AbstractEdge{V}) where V = add_edge!(g, source(e), dst(e))
+LightGraphs.add_edge!(g::AbstractEvolvingGraph{V}, e::TimeEdge{V,T}) where {V, T} = add_edge!(g, source(e), dst(e), e.timestamp)
+LightGraphs.add_edge!(g::AbstractEvolvingGraph{V}, e::TimeWeightedEdge{V,T,W}) where {V,T,W} = 
+    add_edge!(g, source(v1), target(v2), e.timestamp, weight = e.weight)
+
+function LightGraphs.add_vertex!(g::AbstractStaticGraph{V}) where V
+    nnodes = num_nodes(g)
+    add_node!(g,nnodes+1)
+end
 
 # interface to implement
     # LightGraphs.AbstractEdge
     # LightGraphs.AbstractEdgeIter
     # LightGraphs.AbstractGraph
-    # Base.reverse
-    # LightGraphs.add_edge!
-    # LightGraphs.add_vertex!
-    # LightGraphs.dst
-    # LightGraphs.edges
-    # LightGraphs.edgetype
-    # LightGraphs.has_edge
-    # LightGraphs.has_vertex
-    # LightGraphs.inneighbors
-    # LightGraphs.is_directed
-    # LightGraphs.ne
-    # LightGraphs.nv
-    # LightGraphs.outneighbors
     # LightGraphs.rem_edge!
     # LightGraphs.rem_vertex!
-    # LightGraphs.src
-    # LightGraphs.vertices

--- a/src/read_write/lg_interface.jl
+++ b/src/read_write/lg_interface.jl
@@ -39,7 +39,6 @@ end
 # conversions
 LightGraphs.SimpleGraph(g::AbstractStaticGraph{V}) where V = LightGraphs.SimpleGraph(sparse_adjacency_matrix(g))
 
-
 # TODO not implemented
 # interface to implement
     # LightGraphs.AbstractEdge

--- a/src/read_write/lg_interface.jl
+++ b/src/read_write/lg_interface.jl
@@ -1,6 +1,5 @@
 LightGraphs.nv(g::AbstractGraph{V,E}) where {V,E} = num_nodes(g)
 LightGraphs.ne(g::AbstractGraph{V,E}) where {V,E} = num_edges(g)
-LightGraphs.is_directed(g::AbstractGraph{V,E}) where {V,E} = is_directed(g)
 
 function LightGraphs.outneighbors(g::AbstractStaticGraph{NT,E}, v::V) where {V, NT<:AbstractNode{V},E}
     edges = out_edges(g, v)
@@ -25,6 +24,8 @@ LightGraphs.edgetype(::AbstractGraph{V,E}) where {V,E} = E
 
 LightGraphs.vertices(g::AbstractGraph{V,E}) where {V,E} = nodes(g)
 
+LightGraphs.is_directed(g::AbstractGraph{V,E}) where {V,E} = is_directed(g)
+
 LightGraphs.add_edge!(g::AbstractStaticGraph{V}, e::AbstractEdge{ET}) where {V,ET} = add_edge!(g, LightGraphs.src(e), LightGraphs.dst(e))
 LightGraphs.add_edge!(g::AbstractEvolvingGraph{V,E,T}, e::TimeEdge{ET}) where {V, E, T, ET} = add_edge!(g, LightGraphs.src(e), LightGraphs.dst(e), e.timestamp)
 LightGraphs.add_edge!(g::AbstractEvolvingGraph{V,E,T}, e::WeightedTimeEdge{EV,ET,EW}) where {V,E,T,EV,ET,EW} = 
@@ -35,6 +36,11 @@ function LightGraphs.add_vertex!(g::AbstractStaticGraph{V,E}) where {V,E}
     add_node!(g,nnodes+1)
 end
 
+# conversions
+LightGraphs.SimpleGraph(g::AbstractStaticGraph{V}) where V = LightGraphs.SimpleGraph(sparse_adjacency_matrix(g))
+
+
+# TODO not implemented
 # interface to implement
     # LightGraphs.AbstractEdge
     # LightGraphs.AbstractEdgeIter

--- a/src/read_write/lg_interface.jl
+++ b/src/read_write/lg_interface.jl
@@ -1,32 +1,35 @@
-LightGraphs.nv(g::AbstractGraph{V,E}) where {V,E} = num_nodes(g)
-LightGraphs.ne(g::AbstractGraph{V,E}) where {V,E} = num_edges(g)
+LightGraphs.nv(g::AbstractStaticGraph{V,E}) where {V,E} = num_nodes(g)
+LightGraphs.ne(g::AbstractStaticGraph{V,E}) where {V,E} = num_edges(g)
 
 function LightGraphs.outneighbors(g::AbstractStaticGraph{NT,E}, v::V) where {V, NT<:AbstractNode{V},E}
     edges = out_edges(g, v)
     return Node{V}[target(e) for e in edges]
 end
+LightGraphs.outneighbors(g::AbstractStaticGraph{V,E}, v::V) where {V,E} = LightGraphs.outneighbors(g,node_key(v))
 
 function LightGraphs.inneighbors(g::AbstractStaticGraph{NT,E}, v::V) where {V, NT<:AbstractNode{V},E}
     edges = in_edges(g, v)
     return Node{V}[source(e) for e in edges]
 end
+LightGraphs.inneighbors(g::AbstractStaticGraph{V,E}, v::V) where {V,E} = LightGraphs.inneighbors(g,node_key(v))
 
 LightGraphs.src(e::AbstractEdge{V}) where V = source(e)
 LightGraphs.dst(e::AbstractEdge{V}) where V = target(e)
 
-LightGraphs.has_edge(g::AbstractGraph{V,E}, e::AbstractEdge{V}) where {V,E} = has_edge(g,e)
-LightGraphs.has_vertex(g::AbstractGraph{V,E}, n::AbstractNode{V}) where {V,E} = has_node(g,n)
+LightGraphs.has_edge(g::AbstractStaticGraph{V,E}, e::AbstractEdge{V}) where {V,E} = has_edge(g,e)
+LightGraphs.has_vertex(g::AbstractStaticGraph{V,E}, n::AbstractNode{V}) where {V,E} = has_node(g,n)
 
 Base.reverse(e::AbstractEdge{V}) where V = edge_reverse(e)
 
-LightGraphs.edges(g::AbstractGraph{V,E}) where {V,E} = edges(g)
-LightGraphs.edgetype(::AbstractGraph{V,E}) where {V,E} = E
+LightGraphs.edges(g::AbstractStaticGraph{V,E}) where {V,E} = edges(g)
+LightGraphs.edgetype(::AbstractStaticGraph{V,E}) where {V,E} = E
 
-LightGraphs.vertices(g::AbstractGraph{V,E}) where {V,E} = nodes(g)
+LightGraphs.vertices(g::AbstractStaticGraph{V,E}) where {V,E} = nodes(g)
 
-LightGraphs.is_directed(g::AbstractGraph{V,E}) where {V,E} = is_directed(g)
+LightGraphs.is_directed(g::AbstractStaticGraph{V,E}) where {V,E} = is_directed(g)
 
-LightGraphs.add_edge!(g::AbstractStaticGraph{V}, e::AbstractEdge{ET}) where {V,ET} = add_edge!(g, LightGraphs.src(e), LightGraphs.dst(e))
+LightGraphs.add_edge!(g::AbstractStaticGraph{V,E}, e::AbstractEdge{V}) where {V,E} = add_edge!(g, LightGraphs.src(e), LightGraphs.dst(e))
+LightGraphs.add_edge!(g::AbstractStaticGraph{V,E}, e::AbstractEdge{T}) where {T, V<:AbstractNode{T},E} = add_edge!(g, LightGraphs.src(e), LightGraphs.dst(e))
 LightGraphs.add_edge!(g::AbstractEvolvingGraph{V,E,T}, e::TimeEdge{ET}) where {V, E, T, ET} = add_edge!(g, LightGraphs.src(e), LightGraphs.dst(e), e.timestamp)
 LightGraphs.add_edge!(g::AbstractEvolvingGraph{V,E,T}, e::WeightedTimeEdge{EV,ET,EW}) where {V,E,T,EV,ET,EW} = 
     add_edge!(g, source(v1), target(v2), e.timestamp, weight = e.weight)
@@ -43,6 +46,6 @@ LightGraphs.SimpleDiGraph(g::AbstractStaticGraph{V,E}) where {V,E} = LightGraphs
 # interface to implement
     # LightGraphs.AbstractEdge
     # LightGraphs.AbstractEdgeIter
-    # LightGraphs.AbstractGraph
+	# LightGraphs.AbstractGraph
     # LightGraphs.rem_edge!
     # LightGraphs.rem_vertex!

--- a/src/read_write/lg_interface.jl
+++ b/src/read_write/lg_interface.jl
@@ -1,0 +1,24 @@
+
+LightGraphs.nv(g::DiGraph) = length(g.nodes)
+
+# interface to implement
+    # LightGraphs.AbstractEdge
+    # LightGraphs.AbstractEdgeIter
+    # LightGraphs.AbstractGraph
+    # Base.reverse
+    # LightGraphs.add_edge!
+    # LightGraphs.add_vertex!
+    # LightGraphs.dst
+    # LightGraphs.edges
+    # LightGraphs.edgetype
+    # LightGraphs.has_edge
+    # LightGraphs.has_vertex
+    # LightGraphs.inneighbors
+    # LightGraphs.is_directed
+    # LightGraphs.ne
+    # LightGraphs.nv
+    # LightGraphs.outneighbors
+    # LightGraphs.rem_edge!
+    # LightGraphs.rem_vertex!
+    # LightGraphs.src
+    # LightGraphs.vertices

--- a/src/read_write/lg_interface.jl
+++ b/src/read_write/lg_interface.jl
@@ -37,7 +37,7 @@ function LightGraphs.add_vertex!(g::AbstractStaticGraph{V,E}) where {V,E}
 end
 
 # conversions
-LightGraphs.SimpleGraph(g::AbstractStaticGraph{V}) where V = LightGraphs.SimpleGraph(sparse_adjacency_matrix(g))
+LightGraphs.SimpleDiGraph(g::AbstractStaticGraph{V}) where V = LightGraphs.SimpleDiGraph(sparse_adjacency_matrix(g))
 
 # TODO not implemented
 # interface to implement

--- a/src/read_write/lg_interface.jl
+++ b/src/read_write/lg_interface.jl
@@ -31,13 +31,13 @@ LightGraphs.add_edge!(g::AbstractEvolvingGraph{V,E,T}, e::TimeEdge{ET}) where {V
 LightGraphs.add_edge!(g::AbstractEvolvingGraph{V,E,T}, e::WeightedTimeEdge{EV,ET,EW}) where {V,E,T,EV,ET,EW} = 
     add_edge!(g, source(v1), target(v2), e.timestamp, weight = e.weight)
 
-function LightGraphs.add_vertex!(g::AbstractStaticGraph{V,E}) where {V,E}
+function LightGraphs.add_vertex!(g::AbstractStaticGraph{V,E}) where {V<:AbstractNode{T},E} where T<:Integer
     nnodes = num_nodes(g)
     add_node!(g,nnodes+1)
 end
 
 # conversions
-LightGraphs.SimpleDiGraph(g::AbstractStaticGraph{V}) where V = LightGraphs.SimpleDiGraph(sparse_adjacency_matrix(g))
+LightGraphs.SimpleDiGraph(g::AbstractStaticGraph{V,E}) where {V,E} = LightGraphs.SimpleDiGraph(sparse_adjacency_matrix(g))
 
 # TODO not implemented
 # interface to implement

--- a/src/read_write/lg_interface.jl
+++ b/src/read_write/lg_interface.jl
@@ -2,12 +2,12 @@ LightGraphs.nv(g::AbstractGraph{V,E}) where {V,E} = num_nodes(g)
 LightGraphs.ne(g::AbstractGraph{V,E}) where {V,E} = num_edges(g)
 LightGraphs.is_directed(g::AbstractGraph{V,E}) where {V,E} = is_directed(g)
 
-function LightGraphs.outneighbors(g::AbstractStaticGraph{V,E}, v::V) where {V,E}
+function LightGraphs.outneighbors(g::AbstractStaticGraph{NT,E}, v::V) where {V, NT<:AbstractNode{V},E}
     edges = out_edges(g, v)
     return Node{V}[target(e) for e in edges]
 end
 
-function LightGraphs.inneighbors(g::AbstractStaticGraph{V,E}, v::V) where {V,E}
+function LightGraphs.inneighbors(g::AbstractStaticGraph{NT,E}, v::V) where {V, NT<:AbstractNode{V},E}
     edges = in_edges(g, v)
     return Node{V}[source(e) for e in edges]
 end
@@ -21,7 +21,7 @@ LightGraphs.has_vertex(g::AbstractGraph{V,E}, n::AbstractNode{V}) where {V,E} = 
 Base.reverse(e::AbstractEdge{V}) where V = edge_reverse(e)
 
 LightGraphs.edges(g::AbstractGraph{V,E}) where {V,E} = edges(g)
-LightGraphs.edgetype(::AbstractGraph{V,E}) where {V,E} = AbstractEdge{V}
+LightGraphs.edgetype(::AbstractGraph{V,E}) where {V,E} = E
 
 LightGraphs.vertices(g::AbstractGraph{V,E}) where {V,E} = nodes(g)
 

--- a/src/read_write/lg_interface.jl
+++ b/src/read_write/lg_interface.jl
@@ -30,9 +30,6 @@ LightGraphs.is_directed(g::AbstractStaticGraph{V,E}) where {V,E} = is_directed(g
 
 LightGraphs.add_edge!(g::AbstractStaticGraph{V,E}, e::AbstractEdge{V}) where {V,E} = add_edge!(g, LightGraphs.src(e), LightGraphs.dst(e))
 LightGraphs.add_edge!(g::AbstractStaticGraph{V,E}, e::AbstractEdge{T}) where {T, V<:AbstractNode{T},E} = add_edge!(g, LightGraphs.src(e), LightGraphs.dst(e))
-LightGraphs.add_edge!(g::AbstractEvolvingGraph{V,E,T}, e::TimeEdge{ET}) where {V, E, T, ET} = add_edge!(g, LightGraphs.src(e), LightGraphs.dst(e), e.timestamp)
-LightGraphs.add_edge!(g::AbstractEvolvingGraph{V,E,T}, e::WeightedTimeEdge{EV,ET,EW}) where {V,E,T,EV,ET,EW} = 
-    add_edge!(g, source(v1), target(v2), e.timestamp, weight = e.weight)
 
 function LightGraphs.add_vertex!(g::AbstractStaticGraph{V,E}) where {V<:AbstractNode{T},E} where T<:Integer
     nnodes = num_nodes(g)

--- a/src/read_write/lg_interface.jl
+++ b/src/read_write/lg_interface.jl
@@ -1,36 +1,36 @@
-LightGraphs.nv(g::AbstractGraph) = num_nodes(g)
-LightGraphs.ne(g::AbstractGraph) = num_edges(g)
-LightGraphs.is_directed(g::AbstractGraph) = is_directed(g)
+LightGraphs.nv(g::AbstractGraph{V,E}) where {V,E} = num_nodes(g)
+LightGraphs.ne(g::AbstractGraph{V,E}) where {V,E} = num_edges(g)
+LightGraphs.is_directed(g::AbstractGraph{V,E}) where {V,E} = is_directed(g)
 
-function LightGraphs.outneighbors(g::AbstractStaticGraph{V}, v::V) where V
+function LightGraphs.outneighbors(g::AbstractStaticGraph{V,E}, v::V) where {V,E}
     edges = out_edges(g, v)
     return Node{V}[target(e) for e in edges]
 end
 
-function LightGraphs.inneighbors(g::AbstractStaticGraph{V}, v::V) where V
+function LightGraphs.inneighbors(g::AbstractStaticGraph{V,E}, v::V) where {V,E}
     edges = in_edges(g, v)
     return Node{V}[source(e) for e in edges]
 end
 
-LightGraphs.src(e::AbstractEdge{V}) where V = source(e) 
-LightGraphs.dst(e::AbstractEdge{V}) where V = target(e) 
+LightGraphs.src(e::AbstractEdge{V}) where V = source(e)
+LightGraphs.dst(e::AbstractEdge{V}) where V = target(e)
 
-LightGraphs.has_edge(g::AbstractGraph{V}, e::AbstractEdge{V}) where V = has_edge(g,e)
-LightGraphs.has_vertex(g::AbstractGraph{V}, n::AbstractNode{V}) where V = has_node(g,n)
+LightGraphs.has_edge(g::AbstractGraph{V,E}, e::AbstractEdge{V}) where {V,E} = has_edge(g,e)
+LightGraphs.has_vertex(g::AbstractGraph{V,E}, n::AbstractNode{V}) where {V,E} = has_node(g,n)
 
-function Base.reverse(e::AbstractEdge{V}) where V = edge_reverse(e)
+Base.reverse(e::AbstractEdge{V}) where V = edge_reverse(e)
 
-LightGraphs.edges(g::AbstractGraph{V}) where V = edges(g)
-LightGraphs.edgetype(::AbstractGraph{V}) where V = AbstractEdge{V}
+LightGraphs.edges(g::AbstractGraph{V,E}) where {V,E} = edges(g)
+LightGraphs.edgetype(::AbstractGraph{V,E}) where {V,E} = AbstractEdge{V}
 
-LightGraphs.vertices(g::AbstractGraph{V}) where V = nodes(g)
+LightGraphs.vertices(g::AbstractGraph{V,E}) where {V,E} = nodes(g)
 
-LightGraphs.add_edge!(g::AbstractStaticGraph{V}, e::AbstractEdge{V}) where V = add_edge!(g, source(e), dst(e))
-LightGraphs.add_edge!(g::AbstractEvolvingGraph{V}, e::TimeEdge{V,T}) where {V, T} = add_edge!(g, source(e), dst(e), e.timestamp)
-LightGraphs.add_edge!(g::AbstractEvolvingGraph{V}, e::TimeWeightedEdge{V,T,W}) where {V,T,W} = 
+LightGraphs.add_edge!(g::AbstractStaticGraph{V}, e::AbstractEdge{ET}) where {V,ET} = add_edge!(g, LightGraphs.src(e), LightGraphs.dst(e))
+LightGraphs.add_edge!(g::AbstractEvolvingGraph{V,E,T}, e::TimeEdge{ET}) where {V, E, T, ET} = add_edge!(g, LightGraphs.src(e), LightGraphs.dst(e), e.timestamp)
+LightGraphs.add_edge!(g::AbstractEvolvingGraph{V,E,T}, e::WeightedTimeEdge{EV,ET,EW}) where {V,E,T,EV,ET,EW} = 
     add_edge!(g, source(v1), target(v2), e.timestamp, weight = e.weight)
 
-function LightGraphs.add_vertex!(g::AbstractStaticGraph{V}) where V
+function LightGraphs.add_vertex!(g::AbstractStaticGraph{V,E}) where {V,E}
     nnodes = num_nodes(g)
     add_node!(g,nnodes+1)
 end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+LightGraphs 0.12

--- a/test/lg_interface.jl
+++ b/test/lg_interface.jl
@@ -25,3 +25,5 @@ LightGraphs.add_edge!(g, e)
 
 ## issue with package: not defined for StaticGraphs
 @test_broken LightGraphs.is_directed(g) == is_directed(g) == true
+
+@test LightGraphs.nv(LightGraphs.SimpleDiGraph(g)) == 2

--- a/test/lg_interface.jl
+++ b/test/lg_interface.jl
@@ -1,3 +1,7 @@
+if !Pkg.installed("LightGraphs")
+    Pkg.add("LightGraphs")
+end
+
 import LightGraphs
 
 g = DiGraph{Node{String}, Edge{Node{String}}}()

--- a/test/lg_interface.jl
+++ b/test/lg_interface.jl
@@ -1,0 +1,11 @@
+import LightGraphs
+
+g = DiGraph{Node{String}, Edge{Node{String}}}()
+
+add_node!(g, "a")
+add_node!(g, "b")
+add_edge!(g, "a", "b")
+
+
+@test LightGraphs.nv(g) == 2
+

--- a/test/lg_interface.jl
+++ b/test/lg_interface.jl
@@ -22,5 +22,6 @@ LightGraphs.add_edge!(g, e)
 @test reverse(e) == Edge("a", "b")
 @test LightGraphs.vertices(g) == [Node(1,"a"), Node(2,"b")]
 @test LightGraphs.edgetype(g) == Edge{Node{String}}
+
 ## issue with package: not defined for StaticGraphs
-@test LightGraphs.is_directed(g) == is_directed(g) == true
+@test_broken LightGraphs.is_directed(g) == is_directed(g) == true

--- a/test/lg_interface.jl
+++ b/test/lg_interface.jl
@@ -8,4 +8,5 @@ add_edge!(g, "a", "b")
 
 
 @test LightGraphs.nv(g) == 2
+@test LightGraphs.ne(g) == 2
 

--- a/test/lg_interface.jl
+++ b/test/lg_interface.jl
@@ -26,4 +26,12 @@ LightGraphs.add_edge!(g, e)
 ## issue with package: not defined for StaticGraphs
 @test_broken LightGraphs.is_directed(g) == is_directed(g) == true
 
-@test LightGraphs.nv(LightGraphs.SimpleDiGraph(g)) == 2
+gint = DiGraph{Node{Int},Edge{Node{Int}}}()
+const nnodes = 100
+foreach(i->add_node!(gint, i), 1:nnodes)
+@test LightGraphs.nv(LightGraphs.SimpleDiGraph(gint)) == nnodes
+
+@test LightGraphs.edgetype(gint) <: EvolvingGraphs.AbstractEdge{NT} where {NT<:EvolvingGraphs.AbstractNode{I}} where {I<:Integer}
+
+LightGraphs.add_vertex!(gint)
+@test LightGraphs.nv(gint) == nnodes + 1

--- a/test/lg_interface.jl
+++ b/test/lg_interface.jl
@@ -1,7 +1,3 @@
-if !Pkg.installed("LightGraphs")
-    Pkg.add("LightGraphs")
-end
-
 import LightGraphs
 
 g = DiGraph{Node{String}, Edge{Node{String}}}()

--- a/test/lg_interface.jl
+++ b/test/lg_interface.jl
@@ -9,5 +9,9 @@ add_edge!(g, "a", "b")
 
 @test LightGraphs.nv(g) == 2
 @test LightGraphs.ne(g) == 1
-LightGraphs.add_edge!(g, Edge("b", "a"))
+e = Edge("b", "a")
+@test LightGraphs.src(e) == source(e)
+@test LightGraphs.dst(e) == target(e)
+
+LightGraphs.add_edge!(g, e)
 @test LightGraphs.ne(g) == 2

--- a/test/lg_interface.jl
+++ b/test/lg_interface.jl
@@ -8,5 +8,6 @@ add_edge!(g, "a", "b")
 
 
 @test LightGraphs.nv(g) == 2
+@test LightGraphs.ne(g) == 1
+LightGraphs.add_edge!(g, Edge("b", "a"))
 @test LightGraphs.ne(g) == 2
-

--- a/test/lg_interface.jl
+++ b/test/lg_interface.jl
@@ -22,3 +22,5 @@ LightGraphs.add_edge!(g, e)
 @test reverse(e) == Edge("a", "b")
 @test LightGraphs.vertices(g) == [Node(1,"a"), Node(2,"b")]
 @test LightGraphs.edgetype(g) == Edge{Node{String}}
+## issue with package: not defined for StaticGraphs
+@test LightGraphs.is_directed(g) == is_directed(g) == true

--- a/test/lg_interface.jl
+++ b/test/lg_interface.jl
@@ -15,3 +15,10 @@ e = Edge("b", "a")
 
 LightGraphs.add_edge!(g, e)
 @test LightGraphs.ne(g) == 2
+
+@test LightGraphs.outneighbors(g, "b") == [Node(1, "a")]
+@test LightGraphs.inneighbors(g, "b") == [Node(1, "a")]
+
+@test reverse(e) == Edge("a", "b")
+@test LightGraphs.vertices(g) == [Node(1,"a"), Node(2,"b")]
+@test LightGraphs.edgetype(g) == Edge{Node{String}}

--- a/test/lg_interface.jl
+++ b/test/lg_interface.jl
@@ -24,7 +24,7 @@ LightGraphs.add_edge!(g, e)
 @test LightGraphs.edgetype(g) == Edge{Node{String}}
 
 ## issue with package: not defined for StaticGraphs
-@test_broken LightGraphs.is_directed(g) == is_directed(g) == true
+@test LightGraphs.is_directed(g) == is_directed(g) == true
 
 gint = DiGraph{Node{Int},Edge{Node{Int}}}()
 const nnodes = 100

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ tests = [
          "bfs",
          "dfs",
          "sort_slice",
+         "lg_interface"
          # "shortest_distance",
          # "shortest_temporal_distance",
          # "temporal_efficiency",


### PR DESCRIPTION
Defining the core LightGraphs functions for EvolvingGraphs types.

Big points:  
All abstract types could benefit by inheriting from the LightGraphs abtract graphs to get features for free. Lots of functions are synonyms / doubled between the two packages. Types to inherit from would be edges and graphs. 

All functions which could be defined for all EvolvingGraphs graph types are done as such. Otherwise some functions are restricted to EvolvingGraphs or StaticGraphs.

StaticGraphs can be turned into LightGraphs.SimpleGraphs, loosing the Node IDs information. We could imagine a conversion to MetaGraphs.jl to keep them.

EvolvingGraphs is a more interesting case: I think they can be represented as a path of graphs node(i,t) is linked to node(i,t +- 1), this would be better captured by MetaGraphs.jl too. Still lacking since this would have to be discussed 